### PR TITLE
add hail-opt tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,3 +35,4 @@ add_definitions(${LLVM_DEFINITIONS})
 
 add_subdirectory(include)
 add_subdirectory(lib)
+add_subdirectory(hail-opt)

--- a/examples/test.mlir
+++ b/examples/test.mlir
@@ -1,0 +1,4 @@
+func @test(%arg0: i32) -> i32 {
+  %0 = "optional.missing"() {} : () -> (i32)
+  return %0 : i32
+}

--- a/hail-opt/CMakeLists.txt
+++ b/hail-opt/CMakeLists.txt
@@ -1,0 +1,14 @@
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+set(LIBS
+        ${dialect_libs}
+        ${conversion_libs}
+        MLIROptLib
+        HailOptional
+        )
+add_llvm_executable(hail-opt hail-opt.cpp)
+
+llvm_update_compile_flags(hail-opt)
+target_link_libraries(hail-opt PRIVATE ${LIBS})
+
+mlir_check_all_link_libraries(hail-opt)

--- a/hail-opt/hail-opt.cpp
+++ b/hail-opt/hail-opt.cpp
@@ -1,0 +1,30 @@
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/InitAllPasses.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Support/MlirOptMain.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/ToolOutputFile.h"
+
+#include "Optional/OptionalDialect.h"
+
+int main(int argc, char **argv) {
+    mlir::registerAllPasses();
+    // TODO: Register standalone passes here.
+
+    mlir::DialectRegistry registry;
+    registry.insert<hail::optional::OptionalDialect>();
+    registry.insert<mlir::StandardOpsDialect>();
+    // Add the following to include *all* MLIR Core dialects, or selectively
+    // include what you need like above. You only need to register dialects that
+    // will be *parsed* by the tool, not the one generated
+    // registerAllDialects(registry);
+
+    return mlir::asMainReturnCode(
+            mlir::MlirOptMain(argc, argv, "Hail optimizer driver\n", registry));
+}

--- a/lib/Optional/CMakeLists.txt
+++ b/lib/Optional/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_dialect_library(MLIROptional
+add_mlir_dialect_library(HailOptional
     OptionalDialect.cpp
     OptionalOps.cpp
 


### PR DESCRIPTION
Right now this can't do anything interesting, but it can at least round-trip things like `examples/test.mlir`.