### PR TITLE
Expand ConsumeOp rewrite rule to include PresentOp as well

### DIFF
--- a/examples/consume-present.mlir
+++ b/examples/consume-present.mlir
@@ -1,0 +1,10 @@
+func @consume_present(%i: i32) -> i32 {
+  %0 = "optional.present"(%i) {} : (i32) -> (!optional.option)
+  %1 = "optional.consume_opt"(%0) ( {
+    optional.yield %i: i32
+  }, {
+  ^bb0(%v: i32):
+    optional.yield %v: i32
+  }) : (!optional.option) -> i32
+  return %1 : i32
+}

--- a/include/Optional/OptionalOps.td
+++ b/include/Optional/OptionalOps.td
@@ -7,7 +7,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "OptionalDialect.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
-def PresentOp : Optional_Op<"present", []> {
+def PresentOp : Optional_Op<"present", [NoSideEffect]> {
   let summary = "present";
   let description = [{
   }];


### PR DESCRIPTION
    $ bin/hail-opt --print-ir-before-all --canonicalize ../examples/consume-present.mlir
    // -----// IR Dump Before Canonicalizer //----- //
    module  {
      func @consume_present(%arg0: i32) -> i32 {
        %0 = "optional.present"(%arg0) : (i32) -> !optional.option
        %1 = "optional.consume_opt"(%0) ( {
          optional.yield %arg0 : i32
        },  {
        ^bb0(%arg1: i32):  // no predecessors
          optional.yield %arg1 : i32
        }) : (!optional.option) -> i32
        return %1 : i32
      }
    }

    module  {
      func @consume_present(%arg0: i32) -> i32 {
        return %arg0 : i32
      }
    }