### PR TITLE
add custom assembly for ops

### DIFF
--- a/examples/consume-missing.mlir
+++ b/examples/consume-missing.mlir
@@ -1,10 +1,10 @@
 func @consume_missing(%b: i1, %i: i32) -> i32 {
-  %0 = "optional.missing"() {} : () -> (!optional.option<i32>)
-  %1 = "optional.consume_opt"(%0) ( {
+  %0 = optional.missing : !optional.option<i32>
+  %1 = optional.consume_opt(%0) {
     optional.yield %i: i32
   }, {
   ^bb0(%v: i32):
     optional.yield %v: i32
-  }) : (!optional.option<i32>) -> i32
+  } : (!optional.option<i32>) -> i32
   return %1 : i32
 }

--- a/examples/consume-present.mlir
+++ b/examples/consume-present.mlir
@@ -1,10 +1,10 @@
 func @consume_present(%i: i32) -> i32 {
-  %0 = "optional.present"(%i) {} : (i32) -> (!optional.option<i32>)
-  %1 = "optional.consume_opt"(%0) ( {
+  %0 = optional.present(%i) : (i32) -> !optional.option<i32>
+  %1 = optional.consume_opt(%0) {
     optional.yield %i: i32
   }, {
   ^bb0(%v: i32):
     optional.yield %v: i32
-  }) : (!optional.option<i32>) -> i32
+  } : (!optional.option<i32>) -> i32
   return %1 : i32
 }

--- a/examples/test.mlir
+++ b/examples/test.mlir
@@ -1,4 +1,0 @@
-func @test(%arg0: i32) -> !optional.option {
-  %0 = "optional.missing"() {} : () -> (!optional.option)
-  return %0 : !optional.option
-}

--- a/include/Optional/OptionalDialect.h
+++ b/include/Optional/OptionalDialect.h
@@ -6,6 +6,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 
 #include "Optional/OptionalOpsDialect.h.inc"
 

--- a/include/Optional/OptionalOps.td
+++ b/include/Optional/OptionalOps.td
@@ -3,18 +3,23 @@
 
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 
 include "OptionalDialect.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
-def PresentOp : Optional_Op<"present", [NoSideEffect]> {
+def PresentOp : Optional_Op<"present", [NoSideEffect, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "present";
   let description = [{
   }];
 
   let arguments = (ins Variadic<AnyType>:$values);
 
-  let results = (outs OptionalType);
+  let results = (outs OptionalType:$result);
+
+  let assemblyFormat = [{
+   `(` $values `)` attr-dict `:` functional-type($values, $result)
+  }];
 }
 
 def MissingOp : Optional_Op<"missing", [NoSideEffect]> {
@@ -22,7 +27,9 @@ def MissingOp : Optional_Op<"missing", [NoSideEffect]> {
   let description = [{
   }];
 
-  let results = (outs OptionalType);
+  let results = (outs OptionalType:$result);
+
+  let assemblyFormat = [{ attr-dict `:` type($result) }];
 }
 
 def ConsumeOptOp : Optional_Op<"consume_opt", []> {
@@ -35,6 +42,10 @@ def ConsumeOptOp : Optional_Op<"consume_opt", []> {
   let regions = (region AnyRegion:$missingRegion, AnyRegion:$presentRegion);
 
   let hasCanonicalizer = 1;
+
+  let assemblyFormat = [{
+    `(` $input `)` $missingRegion `,` $presentRegion attr-dict `:` functional-type($input, results)
+  }];
 }
 
 def YieldOp : Optional_Op<"yield", [NoSideEffect, ReturnLike, Terminator,

--- a/lib/Optional/OptionalOps.cpp
+++ b/lib/Optional/OptionalOps.cpp
@@ -50,3 +50,13 @@ void ConsumeOptOp::getCanonicalizationPatterns(RewritePatternSet &results,
     results
         .add<RemoveConsumePresentOrMissing>(context);
 }
+
+LogicalResult PresentOp::inferReturnTypes(MLIRContext *context,
+                                          llvm::Optional<Location> location,
+                                          ValueRange operands,
+                                          DictionaryAttr attributes,
+                                          RegionRange regions,
+                                          llvm::SmallVectorImpl<Type>&inferredReturnTypes) {
+    Type resultType = OptionalType::get(context, operands[0].getType());
+    inferredReturnTypes.push_back(resultType);
+}


### PR DESCRIPTION
Adds custom assembly formats for the current set of ops. I tried to elide the result type from `optional.present`, since it's redundant, by implimenting the `InferTypeOpInterface`. I think the ODS assembly format supports that in the most recent version, but that was done after the release we're using.