### PR TITLE
Make stub Optional lowering pass

### DIFF
--- a/hail-opt/hail-opt.cpp
+++ b/hail-opt/hail-opt.cpp
@@ -12,11 +12,13 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
 
+#include "Conversion/Passes.h"
+
 #include "Optional/OptionalDialect.h"
 
 int main(int argc, char **argv) {
     mlir::registerAllPasses();
-    // TODO: Register standalone passes here.
+    hail::registerOptionalToStandardPass();
 
     mlir::DialectRegistry registry;
     registry.insert<hail::optional::OptionalDialect>();

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(Conversion)
 add_subdirectory(Optional)

--- a/include/Conversion/CMakeLists.txt
+++ b/include/Conversion/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name Conversion)
+mlir_tablegen(Passes.capi.h.inc -gen-pass-capi-header --prefix Conversion)
+mlir_tablegen(Passes.capi.cpp.inc -gen-pass-capi-impl --prefix Conversion)
+add_public_tablegen_target(HailConversionPassIncGen)
+
+add_mlir_doc(Passes ConversionPasses . -gen-pass-doc)

--- a/include/Conversion/OptionalToStandard/OptionalToStandard.h
+++ b/include/Conversion/OptionalToStandard/OptionalToStandard.h
@@ -1,0 +1,25 @@
+#ifndef HAIL_MLIR_DIALECT_OPTIONALTOSTANDARD_H
+#define HAIL_MLIR_DIALECT_OPTIONALTOSTANDARD_H
+
+#include <memory>
+#include <vector>
+
+namespace mlir {
+struct LogicalResult;
+
+class Pass;
+
+class RewritePatternSet;
+//using OwningRewritePatternList = RewritePatternSet;
+} // namespace mlir
+
+namespace hail {
+using namespace mlir;
+void populateOptionalToStdConversionPatterns(RewritePatternSet &patterns);
+
+/// Creates a pass to convert scf.for, scf.if and loop.terminator ops to CFG.
+std::unique_ptr<Pass> createLowerOptionalToSTDPass();
+
+} // namespace mlir
+
+#endif //HAIL_MLIR_DIALECT_OPTIONALTOSTANDARD_H

--- a/include/Conversion/Passes.h
+++ b/include/Conversion/Passes.h
@@ -1,0 +1,14 @@
+#ifndef HAIL_CONVERSION_PASSES_H
+#define HAIL_CONVERSION_PASSES_H
+
+#include "Conversion/OptionalToStandard/OptionalToStandard.h"
+
+namespace hail {
+
+/// Generate the code for registering conversion passes.
+#define GEN_PASS_REGISTRATION
+#include "Conversion/Passes.h.inc"
+
+} // namespace hail
+
+#endif // HAIL_CONVERSION_PASSES_H

--- a/include/Conversion/Passes.td
+++ b/include/Conversion/Passes.td
@@ -1,0 +1,16 @@
+#ifndef HAIL_CONVERSION_PASSES
+#define HAIL_CONVERSION_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+//===----------------------------------------------------------------------===//
+// OptionalToStandard
+//===----------------------------------------------------------------------===//
+
+def OptionalToStandard : Pass<"convert-optional-to-std"> {
+  let summary = "Convert Optional dialect to Standard dialect";
+  let constructor = "hail::createLowerOptionalToSTDPass()";
+  let dependentDialects = ["StandardOpsDialect"];
+}
+
+#endif // HAIL_CONVERSION_PASSES

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(Conversion)
 add_subdirectory(Optional)

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(OptionalToStandard)

--- a/lib/Conversion/OptionalToStandard/CMakeLists.txt
+++ b/lib/Conversion/OptionalToStandard/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_mlir_conversion_library(HailOptionalToStandard
+  OptionalToStandard.cpp
+
+#  ADDITIONAL_HEADER_DIRS
+#  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SCFToStandard
+
+  DEPENDS
+  HailConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRSCF
+  MLIRTransforms
+  )

--- a/lib/Conversion/OptionalToStandard/OptionalToStandard.cpp
+++ b/lib/Conversion/OptionalToStandard/OptionalToStandard.cpp
@@ -1,0 +1,37 @@
+#include "Conversion/OptionalToStandard/OptionalToStandard.h"
+#include "../PassDetail.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+
+using namespace mlir;
+using namespace hail;
+
+namespace {
+
+struct OptionalToStandardPass : public OptionalToStandardBase<OptionalToStandardPass> {
+  void runOnOperation() override;
+};
+
+}
+
+void hail::populateOptionalToStdConversionPatterns(RewritePatternSet &patterns) {
+//  patterns.add<>(patterns.getContext());
+}
+
+void OptionalToStandardPass::runOnOperation() {
+  RewritePatternSet patterns(&getContext());
+  populateOptionalToStdConversionPatterns(patterns);
+  // Configure conversion to lower out .... Anything else is fine.
+  ConversionTarget target(getContext());
+//  target.addIllegalOp<>();
+  target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
+  if (failed(
+          applyPartialConversion(getOperation(), target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<Pass> hail::createLowerOptionalToSTDPass() {
+  return std::make_unique<OptionalToStandardPass>();
+}

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -1,0 +1,17 @@
+#ifndef HAIL_MLIR_DIALECT_PASSDETAIL_H
+#define HAIL_MLIR_DIALECT_PASSDETAIL_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+class StandardOpsDialect;
+
+// Forward declaration from Dialect.h
+template <typename ConcreteDialect>
+void registerDialect(DialectRegistry &registry);
+
+#define GEN_PASS_CLASSES
+#include "Conversion/Passes.h.inc"
+
+} // end namespace mlir
+#endif //HAIL_MLIR_DIALECT_PASSDETAIL_H


### PR DESCRIPTION
The `Standalone` example dialect doesn't include any passes, so I tried to copy the structure from core MLIR. The pass is empty (it has no registered patterns), but it does show up in `bin/hail-opt -h`, and can be run as a no-op with `bin/hail-opt --convert-optional-to-std`.