### PR TITLE
Add llvm-lit/FileCheck program finding

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ To set up the build:
 mkdir build
 cd build
 # same prefix as the install directory above in the build/install LLVM
-MLIR_DIR=~/src/mlir-hail/llvm/lib/cmake/mlir cmake .. -G Ninja
+cmake .. -G Ninja \
+  -DMLIR_DIR=~/src/mlir-hail/llvm/lib/cmake/mlir \
+  -DLLVM_BUILD_BINARY_DIR=~/src/llvm-project/build/bin
+  # ^ this argument is necessary to find llvm-lit and FileCheck for the tests
+  #   they are skipped and a warning printed otherwise
 ```
 
 To build:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,16 @@
 configure_file(lit.site.cfg.py.in lit.site.cfg.py @ONLY)
-add_custom_target(check COMMAND llvm-lit "${CMAKE_CURRENT_BINARY_DIR}" -v
-                  DEPENDS hail-opt)
+
+find_program(LLVM_LIT "llvm-lit"
+    HINTS ${LLVM_TOOLS_BINARY_DIR} ${LLVM_BUILD_BINARY_DIR})
+
+if(${LLVM_LIT})
+    get_filename_component(LLVM_TEST_BINARY_DIR "${LLVM_LIT}" DIRECTORY)
+
+    find_program(FILE_CHECK "FileCheck" HINTS ${LLVM_TEST_BINARY_DIR} REQUIRED)
+
+    add_custom_target(check COMMAND "${CMAKE_COMMAND}" -E env "PATH=$ENV{PATH}:${LLVM_TEST_BINARY_DIR}"
+        "${LLVM_LIT}" "${CMAKE_CURRENT_BINARY_DIR}" -v
+        DEPENDS hail-opt)
+else()
+    message(WARNING "llvm-lit not found, disabling tests")
+endif()


### PR DESCRIPTION
These programs are built, but not installed by llvm. It will usually be
necessary to define LLVM_BUILD_BINARY_DIR on the cmake command line
invocation, like:

    cmake .. -Wno-dev -G Ninja \
        -DCMAKE_C_COMPILER=clang \
        -DCMAKE_CXX_COMPILER=clang++ \
        -DMLIR_DIR=~/src/mlir-hail/llvm/lib/cmake/mlir \
        -DLLVM_BUILD_BINARY_DIR=~/src/llvm-project/build/bin # this one