### PR TITLE
Add verification to consume_opt

### DIFF
--- a/include/Optional/OptionalOps.td
+++ b/include/Optional/OptionalOps.td
@@ -33,7 +33,9 @@ def MissingOp : Optional_Op<"missing", [NoSideEffect]> {
   let assemblyFormat = [{ attr-dict `:` type($result) }];
 }
 
-def ConsumeOptOp : Optional_Op<"consume_opt", []> {
+def ConsumeOptOp : Optional_Op<"consume_opt", [
+      DeclareOpInterfaceMethods<RegionBranchOpInterface>,
+      SingleBlockImplicitTerminator<"YieldOp">]> {
   let summary = "consume_opt";
   let description = [{
   }];
@@ -42,10 +44,19 @@ def ConsumeOptOp : Optional_Op<"consume_opt", []> {
   let results = (outs Variadic<AnyType>);
   let regions = (region SizedRegion<1>:$missingRegion, SizedRegion<1>:$presentRegion);
 
+  let verifier = [{ return ::verify(*this); }];
+
   let hasCanonicalizer = 1;
 
   let assemblyFormat = [{
     `(` $input `)` $missingRegion `,` $presentRegion attr-dict `:` functional-type($input, results)
+  }];
+
+  let extraClassDeclaration = [{
+    mlir::Block *missingBlock();
+    YieldOp missingYield();
+    mlir::Block *presentBlock();
+    YieldOp presentYield();
   }];
 }
 

--- a/lib/Optional/OptionalDialect.cpp
+++ b/lib/Optional/OptionalDialect.cpp
@@ -1,4 +1,3 @@
-
 #include "Optional/OptionalDialect.h"
 
 #include "mlir/IR/Builders.h"


### PR DESCRIPTION
Add DeclareOpInterfaceMethods, and SingleBlockImplicitTerminator to
ConsumeOptOp. This enables us to use MLIR's inbuilt control flow graph
checks, as well as automatically adding a yield if one isn't present.
MLIR's CFG checks will check if the types of the yields are the same.

Add a static verify method that calls RegionBranchOpInterface::verify
and also checks that the presentRegion's block has the same input types
as the optional type. It is a future TODO to make OptionalType properly
variadic in type parameters.