### PR TITLE
implement partial optional lowering pass

### DIFF
--- a/examples/if-optional.mlir
+++ b/examples/if-optional.mlir
@@ -1,0 +1,17 @@
+func @if_optional(%b: i1, %i: i32) -> i32 {
+  %opt = scf.if %b -> !optional.option<i32> {
+    %missing = optional.missing : !optional.option<i32>
+    scf.yield %missing : !optional.option<i32>
+  } else {
+    %present = optional.present(%i) : (i32) -> !optional.option<i32>
+    scf.yield %present : !optional.option<i32>
+  }
+  %1 = optional.consume_opt(%opt) {
+    %zero = constant 0 : i32
+    optional.yield %zero: i32
+  }, {
+  ^bb0(%v: i32):
+    optional.yield %v: i32
+  } : (!optional.option<i32>) -> i32
+  return %1 : i32
+}

--- a/examples/unpack-pack.mlir
+++ b/examples/unpack-pack.mlir
@@ -1,0 +1,5 @@
+func @unpack_pack(%b: i1, %i: i32) -> i32 {
+  %0 = optional.pack_opt(%b, %i) : (i1, i32) -> !optional.option<i32>
+  %b1, %i1 = optional.unpack_opt(%0) : (!optional.option<i32>) -> (i1, i32)
+  std.return %i1 : i32
+}

--- a/include/Conversion/Passes.td
+++ b/include/Conversion/Passes.td
@@ -10,7 +10,7 @@ include "mlir/Pass/PassBase.td"
 def OptionalToStandard : Pass<"convert-optional-to-std"> {
   let summary = "Convert Optional dialect to Standard dialect";
   let constructor = "hail::createLowerOptionalToSTDPass()";
-  let dependentDialects = ["StandardOpsDialect"];
+  let dependentDialects = ["StandardOpsDialect", "scf::SCFDialect"];
 }
 
 #endif // HAIL_CONVERSION_PASSES

--- a/include/Optional/OptionalDialect.h
+++ b/include/Optional/OptionalDialect.h
@@ -4,6 +4,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"

--- a/include/Optional/OptionalOps.td
+++ b/include/Optional/OptionalOps.td
@@ -118,7 +118,9 @@ def UnpackOptionalOp : Optional_Op<"unpack_opt", [NoSideEffect]> {
 
   let arguments = (ins OptionalType:$input);
 
-  let results = (outs I1:$isPresent, AnyType:$value);
+  let results = (outs I1:$isDefined, AnyType:$value);
+
+  let hasCanonicalizer = 1;
 
   let assemblyFormat = [{
     `(` $input `)` attr-dict `:` functional-type($input, results)

--- a/include/Optional/OptionalOps.td
+++ b/include/Optional/OptionalOps.td
@@ -7,8 +7,6 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 
 include "OptionalDialect.td"
 
-include "mlir/Interfaces/SideEffectInterfaces.td"
-
 def PresentOp : Optional_Op<"present", [NoSideEffect, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "present";
   let description = [{
@@ -96,6 +94,46 @@ def ConsumeCoOptOp : CoOptional_Op<"consume_co_opt", [Terminator]> {
 
   let assemblyFormat = [{
     `(` $opt `,` $missing `,` $present `)` attr-dict `:` `(` type($opt) `,` type($missing) `,` type($present) `)`
+  }];
+}
+
+def PackOptionalOp : Optional_Op<"pack_opt", [NoSideEffect]> {
+  let summary = "pack_opt";
+  let description = [{
+  }];
+
+  let arguments = (ins I1:$isPresent, AnyType:$value);
+
+  let results = (outs OptionalType:$result);
+
+  let assemblyFormat = [{
+    `(` operands `)` attr-dict `:` functional-type(operands, $result)
+  }];
+}
+
+def UnpackOptionalOp : Optional_Op<"unpack_opt", [NoSideEffect]> {
+  let summary = "unpack_opt";
+  let description = [{
+  }];
+
+  let arguments = (ins OptionalType:$input);
+
+  let results = (outs I1:$isPresent, AnyType:$value);
+
+  let assemblyFormat = [{
+    `(` $input `)` attr-dict `:` functional-type($input, results)
+  }];
+}
+
+def UndefinedOp : Optional_Op<"undefined", [NoSideEffect]> {
+  let summary = "undefined";
+  let description = [{
+  }];
+
+  let results = (outs AnyType:$result);
+
+  let assemblyFormat = [{
+    attr-dict `:` type($result)
   }];
 }
 

--- a/lib/Conversion/OptionalToStandard/OptionalToStandard.cpp
+++ b/lib/Conversion/OptionalToStandard/OptionalToStandard.cpp
@@ -1,12 +1,16 @@
 #include "Conversion/OptionalToStandard/OptionalToStandard.h"
 #include "../PassDetail.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/DialectConversion.h"
+
+#include "Optional/OptionalDialect.h"
 
 
 using namespace mlir;
 using namespace hail;
+using namespace hail::optional;
 
 namespace {
 
@@ -14,10 +18,56 @@ struct OptionalToStandardPass : public OptionalToStandardBase<OptionalToStandard
   void runOnOperation() override;
 };
 
+struct ConvertPresentOp : public OpConversionPattern<PresentOp> {
+  using OpConversionPattern<PresentOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(PresentOp op, ArrayRef<Value> operands,
+                                ConversionPatternRewriter &rewriter) const {
+    auto constTrue = rewriter.create<ConstantOp>(op.getLoc(), BoolAttr::get(rewriter.getContext(), true));
+    rewriter.replaceOpWithNewOp<PackOptionalOp>(op, op.getType(), constTrue.getResult(), operands[0]);
+
+    return success();
+  }
+};
+
+struct ConvertMissingOp : public OpConversionPattern<MissingOp> {
+  using OpConversionPattern<MissingOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(MissingOp op, ArrayRef<Value> operands,
+                                ConversionPatternRewriter &rewriter) const {
+    auto constFalse = rewriter.create<ConstantOp>(op.getLoc(), BoolAttr::get(rewriter.getContext(), false));
+    auto undefined = rewriter.create<UndefinedOp>(op.getLoc(), op.getType().getValueType());
+    rewriter.replaceOpWithNewOp<PackOptionalOp>(op, op.getType(), constFalse.getResult(), undefined);
+
+    return success();
+  }
+};
+
+struct ConvertConsumeOptOp : public OpRewritePattern<ConsumeOptOp> {
+  using OpRewritePattern<ConsumeOptOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ConsumeOptOp op,
+                                PatternRewriter &rewriter) const {
+    auto unpack = rewriter.create<UnpackOptionalOp>(op.getLoc(), rewriter.getI1Type(), op.input().getType().cast<OptionalType>().getValueType(), op.input());
+    auto ifOp = rewriter.replaceOpWithNewOp<scf::IfOp>(op, op.getResultTypes(), unpack.isDefined(), /* withElseRegion= */ true);
+    rewriter.mergeBlocks(&op.missingRegion().front(), ifOp.elseBlock());
+    rewriter.mergeBlocks(&op.presentRegion().front(), ifOp.thenBlock(), unpack.value());
+    // replace optional.yield with scf.yield
+    auto elseYield = ifOp.elseBlock()->getTerminator();
+    rewriter.setInsertionPointToEnd(ifOp.elseBlock());
+    rewriter.replaceOpWithNewOp<scf::YieldOp>(elseYield, elseYield->getOperands());
+    auto thenYield = ifOp.thenBlock()->getTerminator();
+    rewriter.setInsertionPointToEnd(ifOp.thenBlock());
+    rewriter.replaceOpWithNewOp<scf::YieldOp>(thenYield, thenYield->getOperands());
+
+    return success();
+  }
+};
+
 }
 
 void hail::populateOptionalToStdConversionPatterns(RewritePatternSet &patterns) {
-//  patterns.add<>(patterns.getContext());
+  patterns.add<ConvertPresentOp, ConvertMissingOp, ConvertConsumeOptOp>(patterns.getContext());
 }
 
 void OptionalToStandardPass::runOnOperation() {
@@ -25,7 +75,7 @@ void OptionalToStandardPass::runOnOperation() {
   populateOptionalToStdConversionPatterns(patterns);
   // Configure conversion to lower out .... Anything else is fine.
   ConversionTarget target(getContext());
-//  target.addIllegalOp<>();
+  target.addIllegalOp<PresentOp, MissingOp, ConsumeOptOp>();
   target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
   if (failed(
           applyPartialConversion(getOperation(), target, std::move(patterns))))

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -2,6 +2,7 @@
 #define HAIL_MLIR_DIALECT_PASSDETAIL_H
 
 #include "mlir/Pass/Pass.h"
+#include "mlir/Dialect/SCF/SCF.h"
 
 namespace mlir {
 class StandardOpsDialect;


### PR DESCRIPTION
Adds a lowering pass called `convert-optional-to-std`. It lowers `missing` and `present` to construct a (possibly undefined) value and a boolean, and it lowers `consume_opt` to a `scf.if` branching on the boolean. It inserts `pack` and `unpack` operations to maintain type correctness as needed.