### PR TITLE
Lower undefined

### DIFF
--- a/include/Conversion/Passes.td
+++ b/include/Conversion/Passes.td
@@ -10,7 +10,7 @@ include "mlir/Pass/PassBase.td"
 def OptionalToStandard : Pass<"convert-optional-to-std"> {
   let summary = "Convert Optional dialect to Standard dialect";
   let constructor = "hail::createLowerOptionalToSTDPass()";
-  let dependentDialects = ["StandardOpsDialect", "scf::SCFDialect"];
+  let dependentDialects = ["StandardOpsDialect", "scf::SCFDialect", "LLVM::LLVMDialect"];
 }
 
 #endif // HAIL_CONVERSION_PASSES

--- a/lib/Conversion/OptionalToStandard/OptionalToStandard.cpp
+++ b/lib/Conversion/OptionalToStandard/OptionalToStandard.cpp
@@ -70,6 +70,7 @@ struct ConvertUndefinedOp : public OpRewritePattern<UndefinedOp> {
 
   LogicalResult matchAndRewrite(UndefinedOp op,
                                 PatternRewriter &rewriter) const {
+    // TODO make convert/ensure the result type is legal for LLVM
     rewriter.replaceOpWithNewOp<mlir::LLVM::UndefOp>(op, op.result().getType());
     return success();
   }
@@ -162,7 +163,7 @@ void OptionalToStandardPass::runOnOperation() {
   populateOptionalToStdConversionPatterns(patterns);
   // Configure conversion to lower out .... Anything else is fine.
   ConversionTarget target(getContext());
-  target.addIllegalOp<PresentOp, MissingOp, ConsumeOptOp>();
+  target.addIllegalOp<PresentOp, MissingOp, ConsumeOptOp, UndefinedOp>();
   target.addDynamicallyLegalOp<scf::IfOp>([](scf::IfOp op) {
     for (auto result : op.results()) {
       if (result.getType().isa<OptionalType>()) return false;

--- a/lib/Conversion/OptionalToStandard/OptionalToStandard.cpp
+++ b/lib/Conversion/OptionalToStandard/OptionalToStandard.cpp
@@ -1,7 +1,8 @@
 #include "Conversion/OptionalToStandard/OptionalToStandard.h"
 #include "../PassDetail.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -60,6 +61,16 @@ struct ConvertConsumeOptOp : public OpRewritePattern<ConsumeOptOp> {
     rewriter.setInsertionPointToEnd(ifOp.thenBlock());
     rewriter.replaceOpWithNewOp<scf::YieldOp>(thenYield, thenYield->getOperands());
 
+    return success();
+  }
+};
+
+struct ConvertUndefinedOp : public OpRewritePattern<UndefinedOp> {
+  using OpRewritePattern<UndefinedOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(UndefinedOp op,
+                                PatternRewriter &rewriter) const {
+    rewriter.replaceOpWithNewOp<mlir::LLVM::UndefOp>(op, op.result().getType());
     return success();
   }
 };

--- a/lib/Conversion/OptionalToStandard/OptionalToStandard.cpp
+++ b/lib/Conversion/OptionalToStandard/OptionalToStandard.cpp
@@ -154,7 +154,7 @@ struct ConvertIfReturningOptional : public OpRewritePattern<scf::IfOp> {
 
 void hail::populateOptionalToStdConversionPatterns(RewritePatternSet &patterns) {
   patterns.add<ConvertPresentOp, ConvertMissingOp, ConvertConsumeOptOp,
-               ConvertIfReturningOptional>(patterns.getContext());
+               ConvertUndefinedOp, ConvertIfReturningOptional>(patterns.getContext());
 }
 
 void OptionalToStandardPass::runOnOperation() {

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -2,6 +2,7 @@
 #define HAIL_MLIR_DIALECT_PASSDETAIL_H
 
 #include "mlir/Pass/Pass.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/SCF.h"
 
 namespace mlir {


### PR DESCRIPTION
Types that cannot be easily converted to LLVM types will probably fail this lowering.