### PR TITLE
use UnrealizedConversionCastOp in lowering

### DIFF
--- a/lib/Optional/OptionalOps.cpp
+++ b/lib/Optional/OptionalOps.cpp
@@ -60,21 +60,6 @@ struct RemoveConstructConsumeOpt : public OpRewritePattern<ConsumeCoOptOp> {
   };
 };
 
-struct RemoveUnpackPack : public OpRewritePattern<UnpackOptionalOp> {
-  using OpRewritePattern<UnpackOptionalOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(UnpackOptionalOp unpack,
-                                PatternRewriter &rewriter) const override {
-
-    if (auto pack = unpack.input().getDefiningOp<PackOptionalOp>()) {
-      rewriter.replaceOp(unpack, pack.getOperands());
-      return success();
-    }
-
-    return failure();
-  }
-};
-
 struct RemoveCoOptToOptConversion : public OpRewritePattern<CoOptToOptOp> {
   using OpRewritePattern<CoOptToOptOp>::OpRewritePattern;
 
@@ -94,11 +79,6 @@ struct RemoveCoOptToOptConversion : public OpRewritePattern<CoOptToOptOp> {
 void ConsumeOptOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                MLIRContext *context) {
     results.add<RemoveConsumePresentOrMissing>(context);
-}
-
-void UnpackOptionalOp::getCanonicalizationPatterns(RewritePatternSet &results,
-                                                   MLIRContext *context) {
-  results.add<RemoveUnpackPack>(context);
 }
 
 void ConsumeCoOptOp::getCanonicalizationPatterns(RewritePatternSet &results,


### PR DESCRIPTION
Use the builtin op `unrealized_conversion_cast` instead of custom pack/unpack ops. This will help avoid boilerplate in large scale lowering. Also take advantage of the fold operations defined on `unrealized_conversion_cast` to reduce the number of casts inserted by the conversion pass. It still inserts some unnecessary casts, but that seems unavoidable with the current state of support for 1-to-N type conversion in the dialect conversion infrastructure.