### PR TITLE
add a requiredness analysis pass

### DIFF
--- a/hail-opt/CMakeLists.txt
+++ b/hail-opt/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBS
         MLIROptLib
         HailOptional
         HailControl
+        HailTransforms
         )
 add_llvm_executable(hail-opt hail-opt.cpp)
 

--- a/hail-opt/hail-opt.cpp
+++ b/hail-opt/hail-opt.cpp
@@ -13,13 +13,15 @@
 #include "llvm/Support/ToolOutputFile.h"
 
 #include "Conversion/Passes.h"
+#include "Transforms/Passes.h"
 
 #include "Optional/OptionalDialect.h"
 #include "Control/ControlDialect.h"
 
 int main(int argc, char **argv) {
     mlir::registerAllPasses();
-    hail::registerOptionalToStandardPass();
+    hail::registerConversionPasses();
+    hail::registerTransformsPasses();
 
     mlir::DialectRegistry registry;
     registry.insert<hail::optional::OptionalDialect>();

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(Control)
 add_subdirectory(Conversion)
 add_subdirectory(Optional)
-add_subdirectory(Control)
+add_subdirectory(Transforms)

--- a/include/Optional/OptionalOps.td
+++ b/include/Optional/OptionalOps.td
@@ -130,36 +130,6 @@ def ConsumeCoOptOp : Optional_Op<"consume_co_opt", [Terminator]> {
   }];
 }
 
-def PackOptionalOp : Optional_Op<"pack_opt", [NoSideEffect]> {
-  let summary = "pack_opt";
-  let description = [{
-  }];
-
-  let arguments = (ins I1:$isPresent, Variadic<AnyType>:$values);
-
-  let results = (outs OptionalType:$result);
-
-  let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` functional-type(operands, $result)
-  }];
-}
-
-def UnpackOptionalOp : Optional_Op<"unpack_opt", [NoSideEffect]> {
-  let summary = "unpack_opt";
-  let description = [{
-  }];
-
-  let arguments = (ins OptionalType:$input);
-
-  let results = (outs I1:$isDefined, Variadic<AnyType>:$values);
-
-  let hasCanonicalizer = 1;
-
-  let assemblyFormat = [{
-    `(` $input `)` attr-dict `:` functional-type($input, results)
-  }];
-}
-
 def UndefinedOp : Optional_Op<"undefined", [NoSideEffect]> {
   let summary = "undefined";
   let description = [{

--- a/include/Transforms/CMakeLists.txt
+++ b/include/Transforms/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name Transforms)
+mlir_tablegen(Transforms.capi.h.inc -gen-pass-capi-header --prefix Transforms)
+mlir_tablegen(Transforms.capi.cpp.inc -gen-pass-capi-impl --prefix Transforms)
+add_public_tablegen_target(HailTransformsPassIncGen)
+
+add_mlir_doc(Passes GeneralPasses ./ -gen-pass-doc)

--- a/include/Transforms/Passes.h
+++ b/include/Transforms/Passes.h
@@ -1,0 +1,20 @@
+#ifndef HAIL_TRANSFORMS_PASSES_H
+#define HAIL_TRANSFORMS_PASSES_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace hail {
+/// Creates a pass which performs sparse conditional constant propagation over
+/// nested operations.
+std::unique_ptr <mlir::Pass> createRequirednessPropagationPass();
+
+//===----------------------------------------------------------------------===//
+// Registration
+//===----------------------------------------------------------------------===//
+
+/// Generate the code for registering passes.
+#define GEN_PASS_REGISTRATION
+#include "Transforms/Passes.h.inc"
+} // end namespace hail
+
+#endif //HAIL_TRANSFORMS_PASSES_H

--- a/include/Transforms/Passes.td
+++ b/include/Transforms/Passes.td
@@ -1,0 +1,14 @@
+#ifndef HAIL_TRANSFORMS_PASSES
+#define HAIL_TRANSFORMS_PASSES
+
+include "mlir/Pass/PassBase.td"
+include "mlir/Rewrite/PassUtil.td"
+
+def RequirednessPropagation : Pass<"requiredness-propagation"> {
+  let summary = "Requiredness Propagation";
+  let description = [{
+  }];
+  let constructor = "hail::createRequirednessPropagationPass()";
+}
+
+#endif // HAIL_TRANSFORMS_PASSES

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(Control)
 add_subdirectory(Conversion)
 add_subdirectory(Optional)
-add_subdirectory(Control)
+add_subdirectory(Transforms)

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_mlir_library(HailTransforms
+  RequirednessPropagation.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/Transforms
+
+  DEPENDS
+  HailTransformsPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRAnalysis
+  MLIRTransforms
+  MLIRPass
+)

--- a/lib/Transforms/PassDetail.h
+++ b/lib/Transforms/PassDetail.h
@@ -1,0 +1,9 @@
+#ifndef HAIL_TRANSFORMS_PASSDETAIL_H
+#define HAIL_TRANSFORMS_PASSDETAIL_H
+
+#include "mlir/Pass/Pass.h"
+
+#define GEN_PASS_CLASSES
+#include "Transforms/Passes.h.inc"
+
+#endif //HAIL_TRANSFORMS_PASSDETAIL_H

--- a/lib/Transforms/RequirednessPropagation.cpp
+++ b/lib/Transforms/RequirednessPropagation.cpp
@@ -1,0 +1,132 @@
+#include "PassDetail.h"
+#include "mlir/Analysis/DataFlowAnalysis.h"
+#include "Optional/OptionalDialect.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "Transforms/Passes.h"
+
+using namespace mlir;
+using namespace hail::optional;
+
+namespace {
+struct RPLatticeValue {
+  enum class State {
+    NonOptionalType, // value of any non-optional type
+    Mixed, // value might be present or missing
+    Missing, // value is always missing
+    Present // value is always present
+  };
+
+  RPLatticeValue(State state = State::Mixed)
+          : state(state) {}
+
+  static RPLatticeValue getPessimisticValueState(MLIRContext *context) {
+    return {};
+  }
+
+  static RPLatticeValue getPessimisticValueState(Value value) {
+    return {};
+  }
+
+  bool operator==(const RPLatticeValue &rhs) const {
+    return state == rhs.state;
+  }
+
+  static RPLatticeValue join(const RPLatticeValue &lhs,
+                             const RPLatticeValue &rhs) {
+    assert((lhs == State::NonOptionalType) == (rhs == State::NonOptionalType));
+    return lhs == rhs ? lhs : State::Mixed;
+  }
+
+  llvm::StringRef toString() const {
+    switch (state) {
+      case State::NonOptionalType:
+        return "non-optional";
+      case State::Mixed:
+        return "mixed";
+      case State::Missing:
+        return "missing";
+      case State::Present:
+        return "present";
+    }
+  }
+
+  State state;
+};
+
+struct RPAnalysis : public ForwardDataFlowAnalysis<RPLatticeValue> {
+  using ForwardDataFlowAnalysis<RPLatticeValue>::ForwardDataFlowAnalysis;
+
+  ~RPAnalysis() override = default;
+
+  ChangeResult
+  visitOperation(Operation *op,
+                 ArrayRef<LatticeElement<RPLatticeValue> *> operands) final {
+    return llvm::TypeSwitch<Operation *, ChangeResult>(op)
+      .Case<MissingOp>([this](MissingOp op) {
+        return getLatticeElement(op.result()).join(RPLatticeValue::State::Missing);
+      })
+      .Case<PresentOp>([this](PresentOp op) {
+        return getLatticeElement(op.result()).join(RPLatticeValue::State::Present);
+      })
+      // assert all other cases do not involve Optional types, and we just have to
+      // set all states to NonOptionalType
+      .Default([this](Operation *op) -> ChangeResult {
+        ChangeResult changed = ChangeResult::NoChange;
+        for (auto result : op->getResults()) {
+          assert(!result.getType().isa<OptionalType>());
+          changed |= getLatticeElement(result).join(RPLatticeValue::State::NonOptionalType);
+        }
+        for (auto &region : op->getRegions()) {
+          for (auto operand: region.getArguments()) {
+            assert(!operand.getType().isa<OptionalType>());
+            changed |= getLatticeElement(operand).join(RPLatticeValue::State::NonOptionalType);
+          }
+        }
+        return changed;
+      });
+  }
+};
+} // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+// RequirednessPropagation Pass
+//===----------------------------------------------------------------------===//
+
+/// Annotate op with the inferred requiredness of all results with Optional type
+static void rewrite(RPAnalysis &analysis, Operation *op) {
+  MLIRContext *context = op->getContext();
+  llvm::SmallVector<Attribute, 4> resultAttrs;
+  for (auto result: op->getResults()) {
+    if (result.getType().isa<OptionalType>()) {
+      auto state = analysis.lookupLatticeElement(result);
+      auto stringAttr = StringAttr::get(context, state->getValue().toString());
+      resultAttrs.push_back(stringAttr);
+    }
+  }
+  if (resultAttrs.size() != 0)
+    op->setAttr("result_requiredness", ArrayAttr::get(context, resultAttrs));
+}
+
+namespace {
+struct RequirednessPropagation : public RequirednessPropagationBase<RequirednessPropagation> {
+  void runOnOperation() override;
+};
+} // end anonymous namespace
+
+void RequirednessPropagation::runOnOperation() {
+  Operation *rootOp = getOperation();
+
+  RPAnalysis analysis(rootOp->getContext());
+  analysis.run(rootOp);
+  for (auto &region : rootOp->getRegions()) {
+    for (auto &op : region.getOps()) {
+      op.walk([&analysis](Operation *nestedOp) {
+        rewrite(analysis, nestedOp);
+      });
+    }
+  }
+}
+
+std::unique_ptr<Pass> hail::createRequirednessPropagationPass() {
+  return std::make_unique<RequirednessPropagation>();
+}


### PR DESCRIPTION
Right now, just adds annotations to the ir. For each op with any results of optional type, annotates with an array of strings recording the inferred state of each result of optional type.